### PR TITLE
Work toward being Cloud Native and support Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM ruby:2.3-alpine
+
+COPY . /app
+
+WORKDIR /app
+
+RUN apk add --no-cache --virtual .builddeps \
+    build-base \
+  && apk add --no-cache --virtual .rundeps \
+    nodejs \
+    tzdata \
+  && bundle install --without development test \
+  && rake assets:precompile \
+  && chown -R daemon:daemon /app \
+  && apk del .builddeps
+
+ENTRYPOINT ["/app/bin/entrypoint.sh"]
+
+EXPOSE 3000
+
+CMD ["rails", "server", "-b", "0.0.0.0", "-p", "3000"]

--- a/Gemfile
+++ b/Gemfile
@@ -41,3 +41,4 @@ gem 'cancan'
 gem "sprockets", ">= 3.7.2"
 
 gem 'rails_12factor'
+gem 'health_check'

--- a/Gemfile
+++ b/Gemfile
@@ -43,3 +43,4 @@ gem "sprockets", ">= 3.7.2"
 gem 'rails_12factor'
 gem 'health_check'
 gem 'prometheus-client'
+gem 'redis-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -39,3 +39,5 @@ gem 'simple_form'
 gem 'cancan'
 
 gem "sprockets", ">= 3.7.2"
+
+gem 'rails_12factor'

--- a/Gemfile
+++ b/Gemfile
@@ -42,3 +42,4 @@ gem "sprockets", ">= 3.7.2"
 
 gem 'rails_12factor'
 gem 'health_check'
+gem 'prometheus-client'

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,18 @@ gem 'uglifier', '>= 1.3.0'
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
 
+# Serve static files and send logs to STDOUT
+gem 'rails_12factor'
+
+# Health check endpoint
+gem 'health_check'
+
+# Collect and export monitoring metrics
+gem 'prometheus-client'
+
+# Cache store
+gem 'redis-rails'
+
 group :development, :test do
   gem 'byebug'
 end
@@ -39,8 +51,3 @@ gem 'simple_form'
 gem 'cancan'
 
 gem "sprockets", ">= 3.7.2"
-
-gem 'rails_12factor'
-gem 'health_check'
-gem 'prometheus-client'
-gem 'redis-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,6 +103,11 @@ GEM
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.4)
       loofah (~> 2.2, >= 2.2.2)
+    rails_12factor (0.0.3)
+      rails_serve_static_assets
+      rails_stdout_logging
+    rails_serve_static_assets (0.0.5)
+    rails_stdout_logging (0.0.5)
     railties (4.2.10)
       actionpack (= 4.2.10)
       activesupport (= 4.2.10)
@@ -161,6 +166,7 @@ DEPENDENCIES
   jquery-ui-rails
   quiet_assets
   rails (~> 4.2)
+  rails_12factor
   rest-client
   sass-rails (~> 5.0)
   simple_form
@@ -170,4 +176,4 @@ DEPENDENCIES
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.16.2
+   1.17.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,8 @@ GEM
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     gravatar_image_tag (1.2.0)
+    health_check (2.8.0)
+      railties (~> 4.0)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     i18n (0.9.5)
@@ -162,6 +164,7 @@ DEPENDENCIES
   font-awesome-rails
   foundation-rails
   gravatar_image_tag
+  health_check
   jquery-rails
   jquery-ui-rails
   quiet_assets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,6 +119,23 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (12.3.1)
+    redis (4.1.0)
+    redis-actionpack (5.0.2)
+      actionpack (>= 4.0, < 6)
+      redis-rack (>= 1, < 3)
+      redis-store (>= 1.1.0, < 2)
+    redis-activesupport (5.0.7)
+      activesupport (>= 3, < 6)
+      redis-store (>= 1.3, < 2)
+    redis-rack (2.0.5)
+      rack (>= 1.5, < 3)
+      redis-store (>= 1.2, < 2)
+    redis-rails (5.0.2)
+      redis-actionpack (>= 5.0, < 6)
+      redis-activesupport (>= 5.0, < 6)
+      redis-store (>= 1.2, < 2)
+    redis-store (1.6.0)
+      redis (>= 2.2, < 5)
     rest-client (1.8.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
@@ -174,6 +191,7 @@ DEPENDENCIES
   quiet_assets
   rails (~> 4.2)
   rails_12factor
+  redis-rails
   rest-client
   sass-rails (~> 5.0)
   simple_form

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,9 @@ GEM
     netrc (0.10.3)
     nokogiri (1.8.3)
       mini_portile2 (~> 2.3.0)
+    prometheus-client (0.9.0)
+      quantile (~> 0.2.1)
+    quantile (0.2.1)
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
     rack (1.6.10)
@@ -167,6 +170,7 @@ DEPENDENCIES
   health_check
   jquery-rails
   jquery-ui-rails
+  prometheus-client
   quiet_assets
   rails (~> 4.2)
   rails_12factor

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LofoCats UI :cat:
 
-LofoCats is a simple application, consuming the [LofoCats API](https://github.com/iridakos/lofocats_api), built with Ruby on Rails for demo purposes.
+LofoCats is a simple application, consuming the [LofoCats API][lofocats_api], built with Ruby on Rails for demo purposes.
 
 ![Cat entries index](https://3.bp.blogspot.com/-6KEEbALF9c8/VgLFrtF5hoI/AAAAAAAABcI/_QbpgDMU-1c/s1600/cat-entries-index.png)
 
@@ -12,11 +12,10 @@ LofoCats is a simple application, consuming the [LofoCats API](https://github.co
 
 ## Setting up the application
 
-* Clone the repository.
-* Execute <code>bundle install</code> to install required gems.
-* Edit the <code>config/api.yml</code> and update it with the URL of the LofoCats API. By default, the applications will use <code>http://localhost:3001</code>
-* Execute <code>rails server</code> to start the application on the default port.
-* Navigate to [the application's home page](http://localhost:3000) and there you are. For signing in, view  the documentation of the [LofoCats API](https://github.com/iridakos/lofocats_api) to obtain the credentials of the user that you want to use.
+* Clone this repository and [the `lofocats_api` repository][lofocats_api].
+* Execute `docker-compose up` in your copy of the [`lofocats_api` repository][lofocats_api] to start the backend services.
+* Execute `docker-compose up` in this repository to start the application on the default port.
+* Navigate to [the application's home page](http://localhost:3000) and there you are. For signing in, view  the documentation of the [LofoCats API][lofocats_api] to obtain the credentials of the user that you want to use.
 
 ## Behind the scenes
 
@@ -73,3 +72,5 @@ ___
 ### Sign in Page for Mobiles
 
 ![Sign in page for mobiles](https://4.bp.blogspot.com/-8hGbaqUvHn0/VgLGVqKtNRI/AAAAAAAABc4/fe5St4o8OYc/s1600/mobile-sign-in.png)
+
+[lofocats_api]: https://github.com/iridakos/lofocats_api

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+# Remove a potentially pre-existing server.pid for Rails.
+rm -f /app/tmp/pids/server.pid
+
+# Then exec the container's main process (what's set as CMD in the Dockerfile).
+exec "$@"

--- a/config/api.yml
+++ b/config/api.yml
@@ -1,11 +1,12 @@
+default: &default
+  url: <%= ENV['LOFOCATS_API_URL'] || 'http://localhost:3001' %>
+  version: <%= ENV['LOFOCATS_API_VERSION'] || '1' %>
+
 development:
-  url: 'http://localhost:3001'
-  version: '1'
+  <<: *default
 
 test:
-  url: 'http://localhost:3001'
-  version: '1'
+  <<: *default
 
 production:
-  url: 'http://localhost:3001'
-  version: '1'
+  <<: *default

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,6 @@ Bundler.require(*Rails.groups)
 
 module LofocatsUi
   class Application < Rails::Application
-
+    config.middleware.insert_after Rails::Rack::Logger, HealthCheck::MiddlewareHealthcheck
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -32,4 +32,8 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # Allow web console from anywhere since accessed from docker-compose
+  # and then only served on localhost
+  defined? config.web_console.whitelisted_ips = '0.0.0.0/0'
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -73,7 +73,4 @@ Rails.application.configure do
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
-
-  # Do not dump schema after migrations.
-  config.active_record.dump_schema_after_migration = false
 end

--- a/config/initializers/api.rb
+++ b/config/initializers/api.rb
@@ -2,7 +2,7 @@ require 'api/configuration'
 require 'api/resource'
 
 # Load the Api Configuration
-configuration = YAML.load_file("#{Rails.root}/config/api.yml")[Rails.env]
+configuration = YAML.load(ERB.new(File.read("#{Rails.root}/config/api.yml")).result)[Rails.env]
 
 # Set the URL and the desired API version to be used.
 Api::Configuration.url = configuration['url']

--- a/config/initializers/cache.rb
+++ b/config/initializers/cache.rb
@@ -1,2 +1,11 @@
-# For simplicity, user the memory store. The cache store will be used as a session store.
-Rails.application.config.cache_store = :memory_store
+# The cache store will be used as a session store.
+# https://github.com/rails/rails/issues/29489
+if ENV.has_key?('REDIS_URL')
+  Rails.cache = ActiveSupport::Cache.lookup_store(
+    :redis_store,
+    "#{ENV['REDIS_URL']}",
+    { expires_in: 3.days }
+  )
+else
+  Rails.cache = ActiveSupport::Cache.lookup_store(:memory_store)
+end

--- a/config/initializers/health_check.rb
+++ b/config/initializers/health_check.rb
@@ -1,0 +1,21 @@
+HealthCheck.setup do |config|
+  # uri prefix (no leading slash)
+  config.uri = 'health'
+
+  # Text output upon success
+  config.success = 'OK'
+
+  # Run checks from middleware
+  config.middleware_checks = ['middleware', 'standard']
+
+  # You can customize which checks happen on a standard health check
+  config.standard_checks = ['middleware']
+
+  # You can set what tests are run with the 'full' or 'all' parameter
+  config.full_checks = ['cache']
+
+  ### Unreleased and added in https://github.com/ianheggie/health_check/pull/72
+  ## Disable the error message to prevent /health from leaking
+  ## sensitive information
+  #config.include_error_in_response_body = false
+end

--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -1,0 +1,5 @@
+require 'prometheus/middleware/collector'
+require 'prometheus/middleware/exporter'
+
+Rails.application.middleware.unshift Prometheus::Middleware::Collector
+Rails.application.middleware.unshift Prometheus::Middleware::Exporter

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,14 +8,20 @@ services:
     volumes:
       - .:/app
     # Connect to the API network (created by docker-compose in the lofocats_api repo)
-    networks:
+    networks: &networks
       - lofocats_api_default
     environment:
       - RAILS_ENV=development
       - LOFOCATS_API_URL=http://api:3001
       - LOFOCATS_API_VERSION=1
+      - REDIS_URL=redis://redis:6379/0
     ports:
       - 127.0.0.1:3000:3000
+    depends_on:
+      - redis
+  redis:
+    image: redis:4-alpine
+    networks: *networks
 
 networks:
   lofocats_api_default:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3'
+
+services:
+  ui:
+    build: .
+    # Change command to install development dependencies
+    command: sh -c 'apk add build-base && bundle install --with development && rails server -b 0.0.0.0 -p 3000'
+    volumes:
+      - .:/app
+    # Connect to the API network (created by docker-compose in the lofocats_api repo)
+    networks:
+      - lofocats_api_default
+    environment:
+      - RAILS_ENV=development
+      - LOFOCATS_API_URL=http://api:3001
+      - LOFOCATS_API_VERSION=1
+    ports:
+      - 127.0.0.1:3000:3000
+
+networks:
+  lofocats_api_default:
+    external: true


### PR DESCRIPTION
And the same as iridakos/lofocats_api#2 for the UI:

* Add `Dockerfile`:
  * the container can be run as `daemon` (UID 2) instead of `root`
* Add `docker-compose.yml` for development:
  * Mount bind the working directory, so your changes are directly available to the container when developing
  * Use network created by `docker-compose` in `lofocats_api`, this avoids duplicating the backend stack. It could be independent but I'd recommend to use a built image of `lofocats_api` that was pushed to hub.docker.com.
* Accept configuration from environment variables
* Serve static assets
* Send logs to `SDTOUT`
* Add basic health and metrics endpoints
* Use Redis instead of the memory store, so multiple replicas can access the same cache/sessions (I also fixed the memory store config :grin:)